### PR TITLE
Add template-based write_files handling for cloud-init

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -1,3 +1,20 @@
 locals {
-  
+  cloud_init = [
+    for ci in var.cloud_init :
+    merge(ci, {
+      config = merge(ci.config, {
+        write_files = [
+          for wf in lookup(ci.config, "write_files", []) :
+          merge(
+            { for k, v in wf : k => v if k != "template" },
+            {
+              content = base64encode(
+                templatefile("${path.module}/template/${wf.template}", var.gitconfig)
+              )
+            }
+          )
+        ]
+      })
+    })
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "proxmox_virtual_environment_download_file" "image" {
 }
 
 resource "proxmox_virtual_environment_file" "user_cloud_config" {
-  for_each     = { for cloud_init in var.cloud_init : cloud_init.file_name => cloud_init }
+  for_each     = { for cloud_init in local.cloud_init : cloud_init.file_name => cloud_init }
   content_type = each.value.content_type
   datastore_id = each.value.datastore_id
   node_name    = each.value.node_name
@@ -73,5 +73,5 @@ resource "proxmox_virtual_environment_vm" "virtual_machine" {
 
 
 output "debug" {
-  value = yamlencode(var.cloud_init[0].config)
+  value = yamlencode(local.cloud_init[0].config)
 }

--- a/template/gitconfig.tmpl
+++ b/template/gitconfig.tmpl
@@ -1,0 +1,3 @@
+[user]
+    name = ${name}
+    email = ${email}

--- a/variable.tf
+++ b/variable.tf
@@ -34,6 +34,14 @@ variable "ssh" {
   sensitive = true
 }
 
+variable "gitconfig" {
+  description = "Git configuration used to render templates"
+  type = object({
+    name  = string
+    email = string
+  })
+}
+
 variable "image" {
   description = "Image download definitions"
   type = list(object({
@@ -73,8 +81,15 @@ variable "cloud_init" {
       package_update  = optional(bool)
       package_upgrade = optional(bool)
       packages        = optional(list(string))
-      bootcmd         = optional(list(string))
-      runcmd          = optional(list(string))
+      write_files = optional(list(object({
+        encoding    = optional(string)
+        template    = string
+        owner       = optional(string)
+        path        = string
+        permissions = optional(string)
+      })))
+      bootcmd = optional(list(string))
+      runcmd  = optional(list(string))
     }))
   }))
 }


### PR DESCRIPTION
## Summary
- support gitconfig variable and write_files templates in cloud-init
- render template files into base64 write_files entries
- generate cloud-init configs using locals and templates

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a3f2a7d618832c87471036eed42327