### PR TITLE
refactor: group provider settings in object

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -8,14 +8,14 @@ terraform {
 }
 
 provider "proxmox" {
-  endpoint = var.endpoint
-  username = var.username
-  password = var.password
-  insecure = var.insecure
+  endpoint = var.provider_config.endpoint
+  username = var.provider_config.username
+  password = var.provider_config.password
+  insecure = var.provider_config.insecure
 
   ssh {
-    agent    = var.ssh.agent
-    username = var.ssh.username
-    password = var.ssh.password
+    agent    = var.provider_config.ssh.agent
+    username = var.provider_config.ssh.username
+    password = var.provider_config.ssh.password
   }
 }

--- a/variable.tf
+++ b/variable.tf
@@ -1,36 +1,21 @@
-variable "endpoint" {
-  type        = string
-  description = "Proxmox API endpoint, e.g. https://192.168.1.10:8006/"
-  validation {
-    condition     = can(regex("^https?://", var.endpoint))
-    error_message = "endpoint must start with http:// or https://."
-  }
-}
 
-variable "username" {
-  type        = string
-  description = "Proxmox API username (e.g., root@pam)."
-}
-
-variable "password" {
-  type        = string
-  description = "Proxmox API password."
-  sensitive   = true
-}
-
-variable "insecure" {
-  type        = bool
-  description = "Skip TLS verification for Proxmox API."
-  default     = false
-}
-
-variable "ssh" {
-  description = "SSH connection settings for the provider."
+variable "provider_config" {
+  description = "Proxmox provider configuration"
   type = object({
-    agent    = bool
+    endpoint = string
     username = string
     password = string
+    insecure = optional(bool, false)
+    ssh = object({
+      agent    = optional(bool, false)
+      username = string
+      password = string
+    })
   })
+  validation {
+    condition     = can(regex("^https?://", var.provider_config.endpoint))
+    error_message = "provider_config.endpoint must start with http:// or https://."
+  }
   sensitive = true
 }
 


### PR DESCRIPTION
## Summary
- consolidate provider settings into `provider_config` object variable
- update proxmox provider block to use new object

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a3f8a26b90832cb1b48e5d0df0b975